### PR TITLE
Optimize Debian & Ubuntu images for size

### DIFF
--- a/docker/debian8/Dockerfile.zulu-7u191-jdk
+++ b/docker/debian8/Dockerfile.zulu-7u191-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jdk=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jdk=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian8/Dockerfile.zulu-7u191-jre
+++ b/docker/debian8/Dockerfile.zulu-7u191-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian8/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-7u191-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre-headless=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre-headless=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian8/Dockerfile.zulu-8u181-jdk
+++ b/docker/debian8/Dockerfile.zulu-8u181-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jdk=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jdk=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian8/Dockerfile.zulu-8u181-jre
+++ b/docker/debian8/Dockerfile.zulu-8u181-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian8/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-8u181-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:jessie
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre-headless=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre-headless=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-7u191-jdk
+++ b/docker/debian9/Dockerfile.zulu-7u191-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jdk=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jdk=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-7u191-jdk
+++ b/docker/debian9/Dockerfile.zulu-7u191-jdk
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/debian9/Dockerfile.zulu-7u191-jre
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/debian9/Dockerfile.zulu-7u191-jre
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre-headless
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/debian9/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre-headless=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre-headless=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-8u181-jdk
+++ b/docker/debian9/Dockerfile.zulu-8u181-jdk
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/debian9/Dockerfile.zulu-8u181-jdk
+++ b/docker/debian9/Dockerfile.zulu-8u181-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jdk=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jdk=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-8u181-jre
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-8u181-jre
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/debian9/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre-headless=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre-headless=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/debian9/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre-headless
@@ -7,7 +7,7 @@ FROM debian:stretch
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
 RUN apt-get -q update && \
-    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jdk=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jdk=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jre
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-7-azure-jre-headless=7.24.0.2 && \
+    apt-get -y --no-install-recommends install zulu-7-azure-jre-headless=7.24.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jdk
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jdk=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jdk=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jre
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jre
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jre-headless
@@ -1,4 +1,3 @@
-
 # This Zulu OpenJDK Dockerfile and corresponding Docker image are
 # to be used solely with Java applications or Java application components
 # that are being developed for deployment on Microsoft Azure or Azure Stack,
@@ -7,11 +6,10 @@
 FROM ubuntu:bionic
 MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
 
-RUN apt-get -q update
-RUN apt-get -y install gnupg software-properties-common
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+RUN apt-get -q update && \
+    apt-get -y --no-install-recommends install gnupg software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
     apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main" && \
     apt-get -q update && \
-    apt-get -y install zulu-8-azure-jre-headless=8.31.0.2 && \
+    apt-get -y --no-install-recommends install zulu-8-azure-jre-headless=8.31.0.2 && \
     rm -rf /var/lib/apt/lists/*
-


### PR DESCRIPTION
Adding `--no-install-recommends` and removing unnecessary `RUN` commands allows for a smaller docker image. For Ubuntu based JDK 8 the size decreased from 424MB to 335MB.