### PR TITLE
Add CI via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+language: minimal
+services: docker
+
+matrix:
+  include:
+    - os: linux
+      env: VERSION=8u181 OS=alpine
+    - os: linux
+      env: VERSION=8u181 OS=centos
+    - os: linux
+      env: VERSION=8u181 OS=debian8
+    - os: linux
+      env: VERSION=8u181 OS=debian9
+    - os: linux
+      env: VERSION=8u181 OS=ubuntu
+    - os: linux
+      env: VERSION=7u191 OS=alpine
+    - os: linux
+      env: VERSION=7u191 OS=centos
+    - os: linux
+      env: VERSION=7u191 OS=debian8
+    - os: linux
+      env: VERSION=7u191 OS=debian9
+    - os: linux
+      env: VERSION=7u191 OS=ubuntu
+
+install:
+  - git clone https://github.com/docker-library/official-images.git ~/official-images
+
+before_script:
+  - env | sort
+  - cd "docker/$OS"
+  - imageName="java"
+  - tagName="$VERSION-zulu-$OS"
+  - dockerfileSuffix="zulu-$VERSION"
+
+script:
+  - |
+    (
+      set -Eeuo pipefail
+      set -x
+      sed -i -e "s@openjdk@$imageName@g" ~/official-images/test/config.sh
+
+      # JDK
+      docker build -t "$imageName:$tagName-jdk" - < "Dockerfile.$dockerfileSuffix-jdk"
+      ~/official-images/test/run.sh "$imageName:$tagName-jdk"
+
+      # JRE
+      docker build -t "$imageName:$tagName-jre" - < "Dockerfile.$dockerfileSuffix-jre"
+      ~/official-images/test/run.sh "$imageName:$tagName-jre"
+    )
+
+after_script:
+  - docker images


### PR DESCRIPTION
After my previous PR, I think it would be useful to test any changes to the Dockerfiles automatically. I've modelled this `.travis.yml` after the one used by [the OpenJDK Docker images](https://github.com/docker-library/openjdk/blob/master/.travis.yml).

A few things to note:
- It's not possible to build the Windows based images on Travis CI, as they are based on the `ltsc2016` tag whereas Travis uses the `1803` tag
- It's not possible to test the `jre-headless` Dockerfiles with the official test suite, as it only expects `jdk` or `jre`