### PR TITLE
Update MAINTAINER instruction set to LABEL

### DIFF
--- a/docker/alpine/Dockerfile.zulu-11u2-jdk
+++ b/docker/alpine/Dockerfile.zulu-11u2-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-11u2-jre
+++ b/docker/alpine/Dockerfile.zulu-11u2-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-11u2-jre-headless
+++ b/docker/alpine/Dockerfile.zulu-11u2-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u191-jdk
+++ b/docker/alpine/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u191-jre
+++ b/docker/alpine/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/alpine/Dockerfile.zulu-7u191-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u201-jdk
+++ b/docker/alpine/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u201-jre
+++ b/docker/alpine/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-7u201-jre-headless
+++ b/docker/alpine/Dockerfile.zulu-7u201-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u181-jdk
+++ b/docker/alpine/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u181-jre
+++ b/docker/alpine/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/alpine/Dockerfile.zulu-8u181-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u192-jdk
+++ b/docker/alpine/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u192-jre
+++ b/docker/alpine/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/alpine/Dockerfile.zulu-8u192-jre-headless
+++ b/docker/alpine/Dockerfile.zulu-8u192-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM alpine
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/centos/Dockerfile.zulu-11u2-jdk
+++ b/docker/centos/Dockerfile.zulu-11u2-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-11u2-jre
+++ b/docker/centos/Dockerfile.zulu-11u2-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-11u2-jre-headless
+++ b/docker/centos/Dockerfile.zulu-11u2-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u191-jdk
+++ b/docker/centos/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u191-jre
+++ b/docker/centos/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/centos/Dockerfile.zulu-7u191-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u201-jdk
+++ b/docker/centos/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u201-jre
+++ b/docker/centos/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-7u201-jre-headless
+++ b/docker/centos/Dockerfile.zulu-7u201-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u181-jdk
+++ b/docker/centos/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u181-jre
+++ b/docker/centos/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/centos/Dockerfile.zulu-8u181-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u192-jdk
+++ b/docker/centos/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u192-jre
+++ b/docker/centos/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/centos/Dockerfile.zulu-8u192-jre-headless
+++ b/docker/centos/Dockerfile.zulu-8u192-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM centos:latest
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN rpm --import http://repos.azul.com/azul-repo.key && \
     curl http://repos.azul.com/azure-only/zulu-azure.repo -o /etc/yum.repos.d/zulu-azure.repo && \

--- a/docker/debian8/Dockerfile.zulu-11u2-jdk
+++ b/docker/debian8/Dockerfile.zulu-11u2-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-11u2-jre
+++ b/docker/debian8/Dockerfile.zulu-11u2-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-11u2-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-11u2-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-7u191-jdk
+++ b/docker/debian8/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-7u191-jre
+++ b/docker/debian8/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-7u191-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-7u201-jdk
+++ b/docker/debian8/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-7u201-jre
+++ b/docker/debian8/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-7u201-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-7u201-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-8u181-jdk
+++ b/docker/debian8/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-8u181-jre
+++ b/docker/debian8/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-8u181-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian8/Dockerfile.zulu-8u192-jdk
+++ b/docker/debian8/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-8u192-jre
+++ b/docker/debian8/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian8/Dockerfile.zulu-8u192-jre-headless
+++ b/docker/debian8/Dockerfile.zulu-8u192-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:jessie
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-11u2-jdk
+++ b/docker/debian9/Dockerfile.zulu-11u2-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-11u2-jre
+++ b/docker/debian9/Dockerfile.zulu-11u2-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-11u2-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-11u2-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-7u191-jdk
+++ b/docker/debian9/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-7u191-jre
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-7u191-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-7u201-jdk
+++ b/docker/debian9/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-7u201-jre
+++ b/docker/debian9/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-7u201-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-7u201-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-8u181-jdk
+++ b/docker/debian9/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-8u181-jre
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-8u181-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/debian9/Dockerfile.zulu-8u192-jdk
+++ b/docker/debian9/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-8u192-jre
+++ b/docker/debian9/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/debian9/Dockerfile.zulu-8u192-jre-headless
+++ b/docker/debian9/Dockerfile.zulu-8u192-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM debian:stretch
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install dirmngr gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-11u2-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-11u2-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-11u2-jre
+++ b/docker/ubuntu/Dockerfile.zulu-11u2-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-11u2-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-11u2-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jre
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-7u191-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-7u191-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-7u201-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-7u201-jre
+++ b/docker/ubuntu/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-7u201-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-7u201-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jre
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-8u181-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-8u181-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update
 RUN apt-get -y install gnupg software-properties-common

--- a/docker/ubuntu/Dockerfile.zulu-8u192-jdk
+++ b/docker/ubuntu/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-8u192-jre
+++ b/docker/ubuntu/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/ubuntu/Dockerfile.zulu-8u192-jre-headless
+++ b/docker/ubuntu/Dockerfile.zulu-8u192-jre-headless
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM ubuntu:bionic
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN apt-get -q update && \
     apt-get -y --no-install-recommends install gnupg software-properties-common && \

--- a/docker/windowsservercore/Dockerfile.11u2-zulu-jdk
+++ b/docker/windowsservercore/Dockerfile.11u2-zulu-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-11-azure-jdk_11.2.3-11.0.1-win_x64.msi
 RUN setx PACKAGE_DIR zulu-11/11.0.1

--- a/docker/windowsservercore/Dockerfile.11u2-zulu-jre
+++ b/docker/windowsservercore/Dockerfile.11u2-zulu-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-11-azure-jre_11.2.3-11.0.1-win_x64.msi
 RUN setx PACKAGE_DIR zulu-11/11.0.1

--- a/docker/windowsservercore/Dockerfile.zulu-7u191-jdk
+++ b/docker/windowsservercore/Dockerfile.zulu-7u191-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-7-azure-jdk_7.24.0.2-7.0.191-win_x64.msi
 RUN setx PACKAGE_DIR zulu-7/7u191

--- a/docker/windowsservercore/Dockerfile.zulu-7u191-jre
+++ b/docker/windowsservercore/Dockerfile.zulu-7u191-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-7-azure-jre_7.24.0.2-7.0.191-win_x64.msi
 RUN setx PACKAGE_DIR zulu-7/7u191

--- a/docker/windowsservercore/Dockerfile.zulu-7u201-jdk
+++ b/docker/windowsservercore/Dockerfile.zulu-7u201-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-7-azure-jdk_7.25.0.5-7.0.201-win_x64.msi
 RUN setx PACKAGE_DIR zulu-7/8u201

--- a/docker/windowsservercore/Dockerfile.zulu-7u201-jre
+++ b/docker/windowsservercore/Dockerfile.zulu-7u201-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-7-azure-jre_7.25.0.5-7.0.201-win_x64.msi
 RUN setx PACKAGE_DIR zulu-7/8u201

--- a/docker/windowsservercore/Dockerfile.zulu-8u181-jdk
+++ b/docker/windowsservercore/Dockerfile.zulu-8u181-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-8-azure-jdk_8.31.0.2-8.0.181-win_x64.msi
 RUN setx PACKAGE_DIR zulu-8/8u181

--- a/docker/windowsservercore/Dockerfile.zulu-8u181-jre
+++ b/docker/windowsservercore/Dockerfile.zulu-8u181-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-8-azure-jre_8.31.0.2-8.0.181-win_x64.msi
 RUN setx PACKAGE_DIR zulu-8/8u181

--- a/docker/windowsservercore/Dockerfile.zulu-8u192-jdk
+++ b/docker/windowsservercore/Dockerfile.zulu-8u192-jdk
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-8-azure-jdk_8.33.0.1-8.0.192-win_x64.msi
 RUN setx PACKAGE_DIR zulu-8/8u192

--- a/docker/windowsservercore/Dockerfile.zulu-8u192-jre
+++ b/docker/windowsservercore/Dockerfile.zulu-8u192-jre
@@ -5,7 +5,7 @@
 # and are not intended to be used for any other purpose.
 
 FROM microsoft/windowsservercore:ltsc2016
-MAINTAINER Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>
+LABEL maintainer="Zulu Enterprise Container Images <azul-zulu-images@microsoft.com>"
 
 RUN setx PACKAGE zulu-8-azure-jre_8.33.0.1-8.0.192-win_x64.msi
 RUN setx PACKAGE_DIR zulu-8/8u192


### PR DESCRIPTION
Update `MAINTAINER` instruction set to `LABEL` instruction. The `LABEL` instruction is a much more flexible version of this and you should use it instead, as it enables setting any metadata you require, and can be viewed easily, for example with `docker inspect`.

*Note:* the `MAINTAINER` instruction set is deprecated according to the Docker documentation, see:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated